### PR TITLE
크롬 익스텐션 구동시 일부 메일 인식 개선

### DIFF
--- a/chrome/xeit/contentscript.js
+++ b/chrome/xeit/contentscript.js
@@ -1,6 +1,6 @@
 // derived from xeit.js
 function check() {
-    var html = document.body.innerHTML;
+    var html = document.head.innerHTML + document.body.innerHTML;
     return document.getElementById('XEIViewer') ||
            html.indexOf('IniMasPlugin') > -1 ||
            html.indexOf('IniCrossMailObj') > -1 ||
@@ -8,13 +8,14 @@ function check() {
            document.getElementById('MailDec');
 }
 
-// copy of link.js
+// (almost) copy of link.js
 function link() {
     var xeit = document.getElementById('xeit');
     if (xeit) {
         return;
     }
 
+    window.stop();
     var attachment = document.getElementsByTagName('html')[0].outerHTML;
 
     var _body = document.body;

--- a/chrome/xeit/manifest.json
+++ b/chrome/xeit/manifest.json
@@ -26,7 +26,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["contentscript.js"]
+      "js": ["contentscript.js"],
+      "run_at": "document_end"
     }
   ]
 }


### PR DESCRIPTION
크롬 익스텐션에서 일부 메일이 인식되지 않는 현상이 확인되었습니다.
1. 농협카드: 모듈 ID 문자열이 `body`가 아닌 `head`에 있어 인식되지 않았습니다. 일단 `head`까지 같이 확인하는 것으로 수정하였습니다.
2. SK텔레콤(v4): (맥 기준으로) 자동으로 패키지 다운로드를 시도하기 때문에 인젝션 타이밍을 놓쳐버렸습니다. Manifest의 `content_scripts` 설정 중 `run_at`을 `document_end`로 당기고 `window.stop()` 트릭을 적용해서 해결했습니다. 혹시 다른 것들이 안 될 수도 있으니 주의~
