### PR TITLE
하나은행 지원 추가

### DIFF
--- a/xeit.html
+++ b/xeit.html
@@ -354,6 +354,14 @@
                                                     <td></td>
                                                 </tr>
                                                 <tr>
+                                                    <td>하나은행</td>
+                                                    <td>XecureExpress</td>
+                                                    <td>PWD</td>
+                                                    <td>SEED, SHA1</td>
+                                                    <td><i class='icon-ok'></i></td>
+                                                    <td></td>
+                                                </tr>
+                                                <tr>
                                                     <td>한국투자증권</td>
                                                     <td>XecureExpress</td>
                                                     <td>PKCS#7</td>

--- a/xeit.js
+++ b/xeit.js
@@ -90,8 +90,10 @@ var xeit = (function () {
 
             //HACK: 구분자가 '보안메일'로 동일한 발송기관 강제 구분.
             var company = this.ui_desc;
-            if (company === '보안메일' || company === 'ｺｸｾﾈｸﾞﾀﾏ') {
-                if (this.html.indexOf('kbcard') > -1) {
+            if (company === '보안메일' || company === 'ｺｸｾﾈｸﾞﾀﾏ' || company === '���ȸ���') {
+                if (this.info_msg.indexOf('hanabank') > -1) {
+                    company = 'Xeit.hanabank';
+                } else if (this.html.indexOf('kbcard') > -1) {
                     company = 'Xeit.kbcard';
                 } else if (/(?=.*lottecard)(?=.*point)/.test(this.smime_header)) {
                     company = 'Xeit.lottepoint';
@@ -130,6 +132,13 @@ var xeit = (function () {
 
                 'TRUEFRIEND': {
                     name: '한국투자증권',
+                    support: true,
+                    hint: '주민등록번호 뒤',
+                    keylen: 7
+                },
+
+                'Xeit.hanabank': {
+                    name: '하나은행',
                     support: true,
                     hint: '주민등록번호 뒤',
                     keylen: 7


### PR DESCRIPTION
마침 얼마 전에 만들었던 하나은행 e플러스통장의 월별거래내역통지 메일을 받았네요. 기존 메일들과 크게 다른 점은 없습니다. 단, HTML의 인코딩 설정이 누락되어 크롬에서 인식이 제대로 되지 않는 부분을 고려해서 처리하였습니다.
