### PR TITLE
삼성카드 지원 관련

### DIFF
--- a/js/plugins/softforum.js
+++ b/js/plugins/softforum.js
@@ -121,8 +121,9 @@ extend(SoftForum.prototype, {
 
         'Xeit.samsungcard': {
             name: '삼성카드',
-            support: false,
-            hint: '-'
+            support: true,
+            hint: '주민등록번호 뒤',
+            keylen: 7
         },
 
         'Xeit.uplus': {
@@ -165,6 +166,18 @@ extend(SoftForum.prototype, {
         'Xeit.yescard': {
             fix_message: function (message) {
                 return message.replace(/href="#topmove"/g, '');
+            }
+        },
+        'Xeit.samsungcard': {
+            fix_frame: function (frame) {
+                var re = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+                var script = {};
+                while (script = re.exec(frame)) {
+                    if (script[0].indexOf('gowbill') > 0) {
+                        return script[0];
+                    }
+                }
+                return "";
             }
         }
     },
@@ -285,5 +298,14 @@ extend(SoftForum.prototype, {
         }
         //HACK: 뒷 부분의 multipart 메일 본문도 잘라냄.
         return message.replace(/(<\/html>)(?![\s\S]*<\/html>)[\s\S]*/i, '$1');
+    },
+
+    render_framed_message: function (frame, message) {
+        // HACK: 삼성카드 메일의 경우 비암호화 부분에 있는 스크립트에 의존
+        if (this.sender.name == '삼성카드') {
+            return frame + message;
+        } else {
+            return message;
+        }
     }
 });


### PR DESCRIPTION
비 암호화 메일에 작성되어 있는 스크립트에 의존적인 부분이 있는데, 일단은 현재
필요한 스크립트만 따로 추출하여 frame에 포함시키도록 했습니다. 아마도
본래 메일 형식이 잘못된 html 구조를 띄는걸로 봐서는, 앞쪽의 `<center>`
태그를 갈아 치우는게 아닐까 하는 추측 정도를 하고 있습니다.

현재는 xeit가 로딩될때 기존의 메일 전체를 날리기 때문에, 좀 고민을 하다가 
지금과 같이 구현을 했습니다. 일단 의견을 구하는 차원에서 Pull Request를 작성해 봅니다.^^;
