### PR TITLE
우리은행 보안메일

### DIFF
--- a/js/plugins/softforum.js
+++ b/js/plugins/softforum.js
@@ -159,6 +159,13 @@ extend(SoftForum.prototype, {
             support: true,
             hint: '주민등록번호 뒤',
             keylen: 7
+        },
+
+        '우리은행 보안메일': {
+            name: '우리은행',
+            support: true,
+            hint: '설정한 비밀번호',
+            keylen: '4,8'
         }
     },
 

--- a/xeit.html
+++ b/xeit.html
@@ -133,7 +133,7 @@
                 hint = hint || '';
                 if (typeof keylen !== 'undefined') {
                     var placeholder = hint + ' (' + keylen.toString().replace(',', '~') + '자리)';
-                    var pattern = '[0-9]{' + keylen + '}';
+                    var pattern = '[a-zA-Z0-9]{' + keylen + '}';
                 } else {
                     var placeholder = hint;
                     var pattern = '';


### PR DESCRIPTION
- #30 이슈를 해결합니다. 
- 우리은행 보안메일은 이용자가 설정한 비밀번호를 입력하도록 되어 있으며, 비밀번호는 영숫자 혼합(대소문자 구분)으로 4~8자리로 구성되어야 합니다. 그래서 `xeit.html`의 `pattern` 변수를 수정했습니다.
