### PR TITLE
CJ헬로모바일 지원

### DIFF
--- a/js/plugins/initech.js
+++ b/js/plugins/initech.js
@@ -253,6 +253,20 @@ extend(IniTech.prototype, {
             salt: 'consulting'
         },
 
+        MC: {
+            name: 'CJ헬로모바일',
+            support: true,
+            experimental: true,
+            rule: [{
+                hint: '주민등록번호 뒤',
+                size: 7
+            }, {
+                hint: '사업자등록번호',
+                size: 10
+            }],
+            salt: 'cjhello'
+        },
+
         TC: {
             name: 'SKT',
             support: true,

--- a/xeit.html
+++ b/xeit.html
@@ -504,6 +504,14 @@
                                                     <td>농협, 우리은행 등</td>
                                                 </tr>
                                                 <tr>
+                                                    <td>CJ헬로모바일</td>
+                                                    <td>INISAFE Mail</td>
+                                                    <td>?</td>
+                                                    <td>?</td>
+                                                    <td><i class='icon-time'></i></td>
+                                                    <td>확인필요</td>
+                                                </tr>
+                                                <tr>
                                                     <td>KB국민카드</td>
                                                     <td>XecureExpress</td>
                                                     <td>PKCS#7</td>


### PR DESCRIPTION
CJ헬로모바일 지원 [요청](https://twitter.com/Gatsbyesque/status/353754621497450496)을 해주셨는데, 마침 [이니텍](https://github.com/tomyun/xeit/wiki/INISAFE-Mail) 모듈에서 `cjhello`라는 코드를 사용하는 것 같아 실험적으로 추가해봅니다.
