### PR TITLE
jQuery 버전 업데이트

### DIFF
--- a/xeit.html
+++ b/xeit.html
@@ -7,7 +7,7 @@
         <link href='http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css' rel='stylesheet'>
         <link href='http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css' rel='stylesheet'>
         <link href='css/xeit.css' rel='stylesheet'>
-        <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js'></script>
+        <script src='http://ajax.googleapis.com/ajax/libs/jquery/2.0.1/jquery.min.js'></script>
         <script src='http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js'></script>
         <script src='js/deps/srcdoc-polyfill/srcdoc-polyfill.min.js'></script>
         <script src='js/xeit.js'></script>


### PR DESCRIPTION
jQuery 버전이 낮아서 IE10/11 등 신버전을 제대로 지원하지 못하고 있는 것 같습니다. 

기본적으로는 HTML상에 &#x3C;meta http-equiv="X-UA-Compatible" content="IE=7" /&#x3E;과 같은 코드 때문에 최신 엔진을 불러오지 못하여 Xeit가 아예 작동하지 않습니다만, 개발자 모드에서 수동 설정으로 이를 무시하여 IE10 엔진으로 불러왔을 때도 작동하지 않는 문제가 있습니다.

Xeit를 로컬에 클론하여 jQuery 버전을 1.10이 아닌 2.0.1로 올렸을 때 Firefox와 IE10/11 모두 정상 작동하였으므로, 이렇게 jQuery 버전 업을 요청하는 바입니다.

감사합니다.
