### PR TITLE
삼성카드 지원 개선

### DIFF
--- a/js/plugins/softforum.js
+++ b/js/plugins/softforum.js
@@ -234,8 +234,19 @@ extend(SoftForum.prototype, {
             },
 
             'Xeit.samsungcard': {
+                fix_message: function (message) {
+                    var host = message.match(/form\s+.*name=['"]encfrm['"]\s+.*action=['"](.*)['"]/i)[1];
+                    var pvalue = message.match(/input\s+.*name=['"]?pvalue['"]?\s+value=['"]?(\w+)['"]?\s*/i)[1];
+                    var _command = message.match(/input\s+.*name=['"]?_command['"]?\s+value=['"]?(\w+)['"]?\s*/i)[1];
+                    var url = host+'?pvalue='+pvalue+'&_command='+_command;
+                    //HACK: 4px 만큼 줄여주지 않으면 내부 frameset에 의해 스크롤바 겹침.
+                    var style = 'width: 100%; height: calc(100% - 4px); height: -webkit-calc(100% - 4px); border: 0;'
+                    return '<iframe style="'+style+'" src="'+url+'"></iframe>';
+                },
+
                 weave: function (frame, message) {
-                    return frame.replace(/<object id="XEIViewer"[\s\S]*<\/object>/i, message.replace(/\$/g, '$$$$'));
+                    var style = 'width: 100%; height: 100%; margin: 0;';
+                    return '<html><head><body style="'+style+'">'+message+'</body></head></html>';
                 }
             }
         };


### PR DESCRIPTION
드디어 삼성카드 명세서를 구하게 되어 테스트해보니 현재 구조에서는 명세서 페이지로 redirection이 제대로 되지 않았습니다. 지원을 추가했던 당시(#20)에는 잘 되었던 것으로 아는데 어쩌면 삼성카드 보안메일에도 최근에 변경 사항이 있었는지 모르겠네요.

아무튼 원래는 XecureWeb을 통하도록 되어 있는데 해당 URL을 그냥 요청해도 연결이 되는 점을 이용하여 직접 `iframe`을 만들어 불러오도록 구조를 변경하였습니다. 이 과정에서 전체적인 레이아웃 조정(#41)도 함께 진행하였습니다.

`iframe`이 계속 중첩되는 구조에다가 삼성카드측 페이지에서는 `frameset`을 사용하고 있어 스크롤 관련하여 트릭이 약간 들어가기도 했는데요. 일단 맥 사파리/크롬/파이어폭스에서 2013년 5월 명세서가 정상적으로 열리는 것은 확인하였습니다. 파이어폭스에 AdBlock 플러그인을 설치한 상태(#22)에서도 별 문제가 없어 보입니다.
