### PR TITLE
if Chrome that has webstore (for distinguishing Opera)

### DIFF
--- a/xeit.html
+++ b/xeit.html
@@ -292,7 +292,7 @@
                 setupSenderBox();
                 setupPasswordBox(false);
 
-                if (window.chrome && location.search != '?chrome') {
+                if (window.chrome.webstore && location.search != '?chrome') {
                     setupAuthAlert('success', '<strong>나왔습니다!</strong> 크롬에서는 <a href="http://j.mp/xeitce" target="_blank">확장 프로그램</a>으로 더욱 쉽고 편하게 사용하세요.');
                 } else {
                     setupAuthAlert('info', '<strong>걱정마세요!</strong> 비밀번호와 메일 내용을 외부로 전송하거나 저장하지 않아요.');


### PR DESCRIPTION
새 오페라는 크롬 기반이기 때문에 window.chrome이 있지만, 웹스토어까지 지원하지는 않기 때문에 window.chrome.webstore는 없습니다.
이러한 오페라에 크롬 웹앺을 설치하라는 메시지를 띄우지 않기 위해선 window.chrome이 아닌 window.chrome.webstore를 인식해야 할 것입니다.
