### PR TITLE
크롬 확장 자동 등장시 원래 페이지로 돌아가기 지원

### DIFF
--- a/chrome/xeit/background.js
+++ b/chrome/xeit/background.js
@@ -2,3 +2,9 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     chrome.pageAction.show(sender.tab.id);
     sendResponse({});
 });
+
+chrome.pageAction.onClicked.addListener(function (tab) {
+    chrome.tabs.sendMessage(tab.id, 'fallback', function (response) {
+        chrome.pageAction.hide(tab.id);
+    });
+});

--- a/chrome/xeit/contentscript.js
+++ b/chrome/xeit/contentscript.js
@@ -39,6 +39,10 @@ function link() {
 }
 
 function show() {
+    chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+        window.postMessage(request, '*');
+        sendResponse({});
+    });
     chrome.runtime.sendMessage({});
 }
 


### PR DESCRIPTION
크롬 확장은 현재 페이지 내에 보안메일 플러그인 관련 HTML 태그가 인식되면 자동으로 Xeit를 호출해버리는데요. 대부분의 경우에는 실제 보안메일을 여는 것이라 문제가 없지만, 간혹 보안메일이 아님에도 불구하고 동일한 명칭의 태그가 포함되어 있어 잘못 호출되는 경우가 있습니다. 예를 들어 여기 [이슈](https://github.com/tomyun/xeit/pull/42) 페이지 같은 경우인데요. 태그는 있는데 관련 파라미터가 없어서 오류가 발생해버립니다.

이에 확장이 자동으로 작동한 경우에도 원한다면 원래의 페이지로 돌아갈 수 있는 기능을 추가하였습니다. 우측 상단의 확장 아이콘(편지 모양)을 누르면 원래의 페이지를 복원하면서 Xeit 창이 사라집니다.

물론 조금 더 제대로 하려면 위와 같은 상황에서도 오류가 발생하지 않도록 각 plugin의 `init()`에 안전장치를 해주는 것이 좋겠습니다. 이건 다음에..
