### PR TITLE
Safari .webarchive 저장 시 검은 화면 문제 고침

### DIFF
--- a/xeit.html
+++ b/xeit.html
@@ -373,6 +373,8 @@
                 //$mailContent.attr('srcdoc', message);
                 srcDoc.set(content, message);
 
+                $content.attr("data-loaded", new Date());
+
                 $('#xeit-nav a[href="#mail"]').tab('show');
             }
 
@@ -383,7 +385,10 @@
 
             $(document).ready(function () {
                 if (window.self !== window.top) {
-                    loadMail();
+                    if (typeof $('#mail-content').attr("data-loaded") === 'undefined') {
+                        // 내용을 아직 채우지 않은 경우에만 진행. (Safari에서 .webarchive으로 저장해놓은 경우를 위해서)
+                        loadMail();
+                    }
                 } else {
                     loadHelp();
                 }


### PR DESCRIPTION
Safari에서 Xeit으로 복호화한 내용을 .webarchive로 저장해두었다 다시 열면, 화면 전체를 거멓게 덮는 backdrop이 생기는 문제점이 있습니다.  온라인으로 조회하게 하는 방식의 명세서들도 webarchive로 저장하면 내용을 오프라인으로 보관할 수 있다는 장점이 있습니다.  webarchive와 비슷하게 페이지를 저장했다 여는 경우를 위해서 #mail-content에 내용이 없는 경우에만 초기화를 진행하도록 손보았습니다.
