### PR TITLE
서울시ETAX 지원 추가

### DIFF
--- a/js/plugins/softforum.js
+++ b/js/plugins/softforum.js
@@ -53,6 +53,8 @@ extend(SoftForum.prototype, {
                 company = 'Xeit.yescard';
             } else if (this.info_msg.indexOf('miraeassetlife.com') > -1) {
                 company = 'Xeit.miraeassetlife';
+            } else {
+                company = '보안메일';
             }
         } else if (company === '悼剧积疙 焊救皋老') {
             company = '동양생명 보안메일';


### PR DESCRIPTION
이번에 보니까 서울시 주민세 납부 고지서도 보안메일로 받을 수 있네요. 일반적인 XecureExpress 보안메일이기는 한데, 헤더나 초기 HTML에 발송기관을 특정할 수 있을만한 키워드가 없어 제목 표시가 난감하네요. 일단 인코딩 때문에 기관명이 깨져 보이는 부분이라도 '보안메일'로 제대로 표시될 수 있도록 기본값을 넣어주었습니다.

노란색 지원미확인으로 표시되기는 하지만 비밀번호 안내라던지, 실제 복호화 자체에는 문제가 없는 것으로 확인되었습니다.
