### PR TITLE
Safari webarchive 지원

### DIFF
--- a/xeit.html
+++ b/xeit.html
@@ -381,12 +381,16 @@
                 $('#xeit-nav a[href="#help"]').tab('show');
             }
 
+            function isMailAttached() {
+                return (window.self !== window.top);
+            }
+
             function isMailLoaded() {
                 return ($('#mail.active').length > 0);
             }
 
             $(document).ready(function () {
-                if (window.self !== window.top) {
+                if (isMailAttached()) {
                     //HACK: Safari webarchive 처럼 메일이 이미 열려있으면 무시. (#55)
                     if (!isMailLoaded()) {
                         loadMail();


### PR DESCRIPTION
Xeit로 열어놓은 메일을 Safari의 webarchive 기능으로 저장하였다가 다시 부르면 `loadMail()`이 재호출되어 화면이 망가지는 현상을 수정합니다(#55). @netj님의 패치를 기반으로 약간 더 정리해보았습니다.
