### PR TITLE
한화손해보험 + faster PBKDF2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "js/deps/srcdoc-polyfill"]
 	path = js/deps/srcdoc-polyfill
 	url = https://github.com/jugglinmike/srcdoc-polyfill.git
+[submodule "js/deps/node-sjcl-all"]
+	path = js/deps/node-sjcl-all
+	url = https://github.com/alanhoff/node-sjcl-all.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,6 @@
 [submodule "js/deps/srcdoc-polyfill"]
 	path = js/deps/srcdoc-polyfill
 	url = https://github.com/jugglinmike/srcdoc-polyfill.git
-[submodule "js/deps/node-sjcl-all"]
-	path = js/deps/node-sjcl-all
-	url = https://github.com/alanhoff/node-sjcl-all.git
+[submodule "js/deps/sjcl"]
+	path = js/deps/sjcl
+	url = https://github.com/tomyun/sjcl.git

--- a/js/plugins/initech.js
+++ b/js/plugins/initech.js
@@ -54,7 +54,7 @@ extend(IniTech.prototype, {
         } else {
             if (S.version >= 'J 1.0.3') {
                 this.iv = CryptoJS.enc.Base64.parse(S.iv);
-                this.salt = this.iv.clone();
+                this.salt = this.iv.clone() + '';
             } else {
                 this.iv = CryptoJS.enc.Latin1.parse(S.iv);
                 this.salt = CryptoJS.enc.Latin1.parse(this.sender.salt);
@@ -274,7 +274,7 @@ extend(IniTech.prototype, {
                 hint: '주민등록번호 앞',
                 size: 6
             }],
-            // no salt required
+            salt: ''
         },
 
         KA: {
@@ -417,11 +417,10 @@ extend(IniTech.prototype, {
     },
 
     keygenPBKDF2: function (password) {
-        var bits = sjcl.misc.pbkdf2(password,
-            sjcl.codec.hex.toBits(this.salt + ''),
-            5139,
-            this.cipher.algorithm.keySize * 32,
-            function (key) {
+        var salt = sjcl.codec.hex.toBits(this.salt),
+            count = 5139,
+            length = this.cipher.algorithm.keySize * 32;
+        var bits = sjcl.misc.pbkdf2(password, salt, count, length, function (key) {
                 return new sjcl.misc.hmac(key, sjcl.hash.sha1)
             });
         var hex = sjcl.codec.hex.fromBits(bits);

--- a/js/plugins/initech.js
+++ b/js/plugins/initech.js
@@ -54,7 +54,7 @@ extend(IniTech.prototype, {
         } else {
             if (S.version >= 'J 1.0.3') {
                 this.iv = CryptoJS.enc.Base64.parse(S.iv);
-                this.salt = this.iv.clone() + '';
+                this.salt = this.iv.clone();
             } else {
                 this.iv = CryptoJS.enc.Latin1.parse(S.iv);
                 this.salt = CryptoJS.enc.Latin1.parse(this.sender.salt);
@@ -417,7 +417,7 @@ extend(IniTech.prototype, {
     },
 
     keygenPBKDF2: function (password) {
-        var salt = sjcl.codec.hex.toBits(this.salt),
+        var salt = sjcl.codec.hex.toBits(this.salt + ''),
             count = 5139,
             length = this.cipher.algorithm.keySize * 32;
         var bits = sjcl.misc.pbkdf2(password, salt, count, length, function (key) {

--- a/js/plugins/initech.js
+++ b/js/plugins/initech.js
@@ -265,6 +265,17 @@ extend(IniTech.prototype, {
             salt: 'heungkukfire'
         },
 
+        IX: {
+            name: '한화손해보험',
+            support: true,
+            experimental: true,
+            rule: [{
+                hint: '주민등록번호 앞',
+                size: 6
+            }],
+            // no salt required
+        },
+
         KA: {
             name: 'Initech',
             support: true,
@@ -341,6 +352,13 @@ extend(IniTech.prototype, {
 
             TC: {
                 ignore_replacer: true
+            },
+
+            IX: {
+                  fix_frame: function (frame) {
+                      // disable downloading plugin
+                      return frame.replace('CMPlugin_Write', '//CMPlugin_Write');
+                }
             },
         };
     }({

--- a/js/plugins/initech.js
+++ b/js/plugins/initech.js
@@ -3,7 +3,7 @@
 importScripts('deps/crypto-js/build/rollups/tripledes.js',
               'deps/crypto-js/build/rollups/pbkdf1.js',
               'deps/crypto-js/build/rollups/pbkdf2.js',
-              'deps/node-sjcl-all/sjcl.js');
+              'deps/sjcl/sjcl.js');
 
 var IniTech = function (html, contents, question, attachedFile, optData) {
     this.html = html || '';


### PR DESCRIPTION
한화손해보험 추가합니다.
해당 보안 메일은 PBKDF2 를 쓰는데, crypto-js 의 pbkdf2 가 느려
Safari 를 쓰는 경우 Web worker 가 죽는 경우가 발생하네요.
그래서 sjcl 을 쓰도록 수정해봤습니다.
감사합니다.